### PR TITLE
Correct dtype strings for uint8 & int8 dtypes

### DIFF
--- a/zarrita.py
+++ b/zarrita.py
@@ -147,7 +147,7 @@ def _check_dtype(dtype: Any) -> np.dtype:
     if not isinstance(dtype, np.dtype):
         dtype = np.dtype(dtype)
     assert dtype.str in {
-        "|b1", "i1", "u1",
+        "|b1", "|i1", "|u1",
         "<i2", "<i4", "<i8",
         ">i2", ">i4", ">i8",
         "<u2", "<u4", "<u8",


### PR DESCRIPTION
I could be missing something here, but `uint8` and `int8` dtype strings seem incorrect in valid set (in `_check_dtype`). I can't create an array using `uint8`.

```python
In [1]: h = create_hierarchy('test.zr3')
In [2]: a = h.create_array('my_array', shape=(5,10), dtype=np.dtype(np.uint8), chunk_shape=(2,5))
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-19-4c6db059dff1> in <module>
----> 1 a = h.create_array('my_array', shape=(5,10), dtype=np.dtype(np.uint8), chunk_shape=(2,5))

~/github/manzt/zarrita/zarrita.py in create_array(self, path, shape, dtype, chunk_shape, chunk_separator, compressor, fill_value, attrs)
    273         path = _check_path(path)
    274         shape = _check_shape(shape)
--> 275         dtype = _check_dtype(dtype)
    276         chunk_shape = _check_chunk_shape(chunk_shape, shape)
    277         _check_compressor(compressor)

~/github/manzt/zarrita/zarrita.py in _check_dtype(dtype)
    147     if not isinstance(dtype, np.dtype):
    148         dtype = np.dtype(dtype)
--> 149     assert dtype.str in {
    150         "|b1", "i1", "u1",
    151         "<i2", "<i4", "<i8",

AssertionError:
```

Some examples of dtype --> str for 8-bit types:

```python
In [12]: np.dtype(np.uint8).str
Out[12]: '|u1'

In [13]: np.dtype('u1').str
Out[13]: '|u1'

In [14]: np.dtype('i1').str
Out[14]: '|i1'

In [15]: np.dtype('b1').str
Out[15]: '|b1'
```